### PR TITLE
ci: migrate to GitHub-hosted runners and actions/cache

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   zizmor:
     timeout-minutes: 10
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -81,7 +81,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm run test
         --testTimeout=50000
@@ -100,7 +100,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350
@@ -115,7 +115,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350

--- a/.github/workflows/nodejs-dependencies.yml
+++ b/.github/workflows/nodejs-dependencies.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   sherif:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pull-request-content-check.yml
+++ b/.github/workflows/pull-request-content-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate-pr-title:
     name: Validate PR title
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       # https://github.com/amannn/action-semantic-pull-request

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -35,7 +35,7 @@ jobs:
           - path: ./packages/rspeedy/core
             name: rspeedy
             key: RELATIVE_CI_PROJECT_RSPEEDY_CORE_KEY
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     name: Upload ${{ matrix.project.name }}
     env:
       RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY: ${{ secrets.RELATIVE_CI_PROJECT_EXAMPLES_REACT_KEY }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: ubuntu-24.04
             name: Ubuntu
-          # - label: lynx-windows-2022-large
+          # - label: windows-2022
           #   name: Windows
     timeout-minutes: 30
     permissions:
@@ -61,7 +61,7 @@ jobs:
           files: target/nextest/ci/test-report.junit.xml
 
   rustfmt:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -77,7 +77,7 @@ jobs:
         run: cargo fmt --check
 
   clippy:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-bundle-analysis.yml
   code-style-check:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
     permissions: {}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: pnpm eslint . --flag v10_config_lookup_from_file
 
   lighthouse:
@@ -77,7 +77,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       run: |
         ulimit -Sn 655350
@@ -94,7 +94,7 @@ jobs:
         shard: [1, 2]
     name: Playwright Web Elements Test (${{ matrix.shard }}/2)
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       codecov-flags: "e2e"
       web-report-path: "packages/web-platform/web-elements/playwright-report"
@@ -120,7 +120,7 @@ jobs:
   #       #   - thread: MULTI_THREAD
   #       #     render: SSR
   #   with:
-  #     runs-on: lynx-custom-container
+  #     runs-on: ubuntu-24.04
   #     is-web: true
   #     web-report-name: "playwright-${{ matrix.thread }}-${{ matrix.render }}-shard${{ matrix.shard }}"
   #     codecov-flags: "e2e"
@@ -147,7 +147,7 @@ jobs:
         render: [CSR]
         shard: [1, 2]
     with:
-      runs-on: lynx-custom-container
+      runs-on: ubuntu-24.04
       is-web: true
       web-report-name: "playwright-${{ matrix.render }}-shard${{ matrix.shard }}"
       web-report-path: "packages/web-platform/web-core-e2e/playwright-report"
@@ -166,7 +166,7 @@ jobs:
     uses: ./.github/workflows/workflow-test.yml
 
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: |
         pnpm turbo api-extractor -- --local
         if test "$(git diff -- './packages/**/*.api.md' --name-only | wc -l)" -gt 0 ; then
@@ -190,7 +190,7 @@ jobs:
     needs: build
     uses: ./.github/workflows/workflow-test.yml
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: |
         # Generated smoke-test projects do not carry a packageManager pin, so
         # keep this stage on pnpm 10 even when Corepack's registry default moves.
@@ -233,7 +233,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm
         --filter @lynx-js/react-runtime
@@ -259,7 +259,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: pnpm -r run test:type
   test-rstest:
     needs: build
@@ -267,7 +267,7 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
-      runs-on: lynx-ubuntu-24.04-medium
+      runs-on: ubuntu-24.04
       run: >
         pnpm exec rstest run
         -c rstest.config.ts
@@ -281,7 +281,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     name: Kitten Lynx Android Emulator Test
     with:
-      runs-on: lynx-ubuntu-22.04-physical-medium
+      runs-on: ubuntu-22.04
       run: |
         # 4. Start Emulator
         echo "Starting emulator..."
@@ -332,7 +332,7 @@ jobs:
         pnpm --filter @lynx-js/kitten-lynx-test-infra run test --coverage --reporter=github-actions --reporter=dot --reporter=junit --outputFile=test-report.junit.xml --coverage.reporter='json' --coverage.reporter='text' --testTimeout=50000 --no-cache --logHeapUsage --silent
 
   test-typos:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     steps:
       - uses: taiki-e/checkout-action@3ab630d442e198ebb0ca30872832406ca01c46eb # v1.4.0
       - uses: crate-ci/typos@57b11c6b7e54c402ccd9cda953f1072ec4f78e33 # v1.43.5
@@ -346,9 +346,9 @@ jobs:
       matrix:
         runs-on:
           - name: Ubuntu
-            label: lynx-ubuntu-24.04-medium
+            label: ubuntu-24.04
           - name: Windows
-            label: lynx-windows-2022-large
+            label: windows-2022
     name: Vitest (${{ matrix.runs-on.name }})
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/workflow-bench.yml
+++ b/.github/workflows/workflow-bench.yml
@@ -14,7 +14,7 @@ jobs:
     # Error: Event merge_group is not supported by CodSpeed
     # Error: unknown variant `merge_group`, expected one of `push`, `pull_request`, `workflow_dispatch`, `schedule`, `local` at line 1 column 13
     if: github.event_name != 'merge_group'
-    runs-on: lynx-ubuntu-24.04-xlarge
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -25,7 +25,7 @@ jobs:
           package-manager-cache: false
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-build.yml
+++ b/.github/workflows/workflow-build.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   get-merge-base:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       # We have 2 cases:
@@ -71,9 +71,9 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - label: lynx-ubuntu-24.04-xlarge
+          - label: ubuntu-24.04
             name: Ubuntu
-          - label: lynx-windows-2022-large
+          - label: windows-2022
             name: Windows
     timeout-minutes: 30
     needs: get-merge-base
@@ -92,7 +92,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}

--- a/.github/workflows/workflow-bundle-analysis.yml
+++ b/.github/workflows/workflow-bundle-analysis.yml
@@ -10,7 +10,7 @@ env:
   TURBO_TELEMETRY_DISABLED: 1
 jobs:
   build:
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -39,7 +39,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -58,7 +58,7 @@ jobs:
           node-version: "22"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           # We have to be strict here to make sure getting the cache of build-all

--- a/.github/workflows/workflow-website.yml
+++ b/.github/workflows/workflow-website.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     permissions: {}
-    runs-on: lynx-ubuntu-24.04-medium
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -20,7 +20,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - name: TurboCache
-        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: .turbo
           key: turbo-v4-${{ runner.os }}-${{ hashFiles('**/packages/**/src/**/*.rs') }}-${{ github.sha }}


### PR DESCRIPTION
## Summary

Removes the workflow dependency on the `lynx-infra` self-hosted runner pool and on `lynx-infra/cache` (a fork of `actions/cache`), so CI runs entirely on GitHub-official infrastructure.

### Runner migration

| Old (self-hosted)                    | New (GitHub-hosted) |
| ------------------------------------ | ------------------- |
| `lynx-ubuntu-24.04-medium`           | `ubuntu-24.04`      |
| `lynx-ubuntu-24.04-xlarge`           | `ubuntu-24.04`      |
| `lynx-windows-2022-large`            | `windows-2022`      |
| `lynx-ubuntu-22.04-physical-medium`  | `ubuntu-22.04`      |
| `lynx-custom-container`              | `ubuntu-24.04` (Playwright container still pinned via `jobs.<id>.container.image`) |

### Cache migration

All five `lynx-infra/cache@5c6160a…` references swapped for `actions/cache@0400d5f6… # v4.2.4`. The action is API-compatible, so `path` / `key` / `restore-keys` / `fail-on-cache-miss` are untouched and cache continuity is preserved by key.

### Files touched

12 files under `.github/workflows/` — runner labels and cache `uses:` only. No logic changes.

## Things reviewers should know

- **Android emulator job** (`kitten-lynx-android-emulator` in `test.yml`): previously ran on `lynx-ubuntu-22.04-physical-medium` for hardware acceleration. GitHub's `ubuntu-22.04` hosted runner supports nested virtualization / KVM, but if the emulator boot fails in CI, the fallback is to keep this single job on `ubuntu-22.04` paired with `reactivecircus/android-emulator-runner@v2`.
- **Cache continuity**: the first build on the new runners will be a cold cache for `turbo-v4-${{ runner.os }}-…` keys; subsequent runs should hit normally since `runner.os` values (`Linux` / `Windows`) are unchanged from the previous labels.
- **Workflows already on official runners** (`copilot-setup-steps.yml`, `stale.yml`, several `deploy-main.yml` jobs) were not modified.

## Checklist

- [x] Tests updated (or not required) — CI-config-only change.
- [x] Documentation updated (or not required).
- [x] Changeset added, and when a BREAKING CHANGE occurs, it needs to be clearly marked (or not required) — infra-only change, no package changes.